### PR TITLE
Configure ldap bind dn and password from env variables

### DIFF
--- a/eos-ocis-dev/start-ldap
+++ b/eos-ocis-dev/start-ldap
@@ -7,8 +7,8 @@ chmod +x /wait-for-mgm
 /wait-for-mgm;
 echo "----- [ocis] LDAP setup -----";
 authconfig --enableldap --enableldapauth --ldapserver=${EOS_LDAP_HOST} --ldapbasedn="dc=example,dc=org" --update;
-sed -i "s/#binddn cn=.*/binddn cn=reva,ou=sysusers,dc=example,dc=org/" /etc/nslcd.conf;
-sed -i "s/#bindpw .*/bindpw reva/" /etc/nslcd.conf;
+sed -i "s/#binddn cn=.*/binddn ${LDAP_BINDDN}/" /etc/nslcd.conf
+sed -i "s/#bindpw .*/bindpw ${LDAP_BINDPW}/" /etc/nslcd.conf
 # start in debug mode;
 
 nslcd -d

--- a/eos-ocis/setup
+++ b/eos-ocis/setup
@@ -4,8 +4,8 @@ set -x
 
 echo "----- [ocis] LDAP setup -----"
 authconfig --enableldap --enableldapauth --ldapserver=${EOS_LDAP_HOST} --ldapbasedn="dc=example,dc=org" --update
-sed -i "s/#binddn cn=.*/binddn cn=reva,ou=sysusers,dc=example,dc=org/" /etc/nslcd.conf
-sed -i "s/#bindpw .*/bindpw reva/" /etc/nslcd.conf
+sed -i "s/#binddn cn=.*/binddn ${LDAP_BINDDN}/" /etc/nslcd.conf
+sed -i "s/#bindpw .*/bindpw ${LDAP_BINDPW}/" /etc/nslcd.conf
 # start in debug mode
 nslcd -d &
 


### PR DESCRIPTION
Add Configure option for  ldap bind dn and password from env variables

This will be necessary if we want to use an external leap server with eos-stack.