### PR TITLE
Use default value of ldap binddn and passwd if not provided

### DIFF
--- a/eos-ocis-dev/start-ldap
+++ b/eos-ocis-dev/start-ldap
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+LDAP_BINDDN=${LDAP_BINDDN:-cn=reva,ou=sysusers,dc=example,dc=org}
+LDAP_BINDPW=${LDAP_BINDPW:-reva}
 echo "Waiting for EOS MGM"
 echo "until nc -z -w 3 $EOS_MGM_ALIAS 1094; do sleep 2; done;" > /wait-for-mgm
 chmod +x /wait-for-mgm


### PR DESCRIPTION
Use the default value of binddn and bindpw if not provided.
This needs to be configurable when using and external ldap server but for running ocis with its own ldap(glauth) , default settings need to work without giving any values.