### PR TITLE
Start the ldap server from the entrypoint

### DIFF
--- a/eos-ocis-dev/entrypoint
+++ b/eos-ocis-dev/entrypoint
@@ -1,4 +1,7 @@
 #!/bin/sh
 
 make build
+
+/start-ldap &
+
 exec bin/ocis server

--- a/eos-ocis-dev/start-ldap
+++ b/eos-ocis-dev/start-ldap
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+LDAP_BINDDN=${LDAP_BINDDN:-cn=reva,ou=sysusers,dc=example,dc=org}
+LDAP_BINDPW=${LDAP_BINDPW:-reva}
 echo "Waiting for EOS MGM"
 echo "until nc -z -w 3 $EOS_MGM_ALIAS 1094; do sleep 2; done;" > /wait-for-mgm
 chmod +x /wait-for-mgm


### PR DESCRIPTION
Start the ldap server from the entrypoint directly.

With this we will not need to run additional steps after running docker-compose setup for eos shown in
https://owncloud.github.io/ocis/eos/#2-ldap-support