### PR TITLE
Improve eos startup

### DIFF
--- a/eos-fst/setup
+++ b/eos-fst/setup
@@ -9,7 +9,5 @@ for i in {1..4}; do
   eos -r 0 0 -b fs add eosfs${i} fst.testnet:1095 /disks/eosfs${i} default rw
 done
 
-eos space set default on
-
 sleep 2
 eos fs ls

--- a/eos-mgm/setup
+++ b/eos-mgm/setup
@@ -37,4 +37,9 @@ eos mkdir -p /eos/dockertest/reva/users
 eos -r 0 0 -b attr set sys.acl="u:2:rwxc" /eos/dockertest/reva/users
 eos ls -l /eos/dockertest/reva/users
 
+echo; echo "===== [mgm setup] ENABLE TRASHBIN ====="
+eos space config default space.policy.recycle=on
+eos recycle config --add-bin /eos/dockertest/reva/users
+eos recycle config --size 1G
+
 echo; echo "===== [mgm setup] DONE ====="

--- a/eos-mgm/setup
+++ b/eos-mgm/setup
@@ -30,7 +30,25 @@ nslcd
 
 echo; echo "===== [mgm setup] RUNNING SOME CHECKS ====="
 eos group set default.0 on
-eos space set default on
+
+# expect (at least) four fst entries.
+while [ "$(eos fs ls -m | grep host=fst | wc -l)" -lt 4 ]; do
+  echo "waiting for four fst to appear in 'eos fs ls' ..."
+  sleep 3;
+  eos fs ls
+done
+
+# FIXME: Workaround for https://github.com/owncloud/ocis/issues/396
+# - Uploads fail with "mismatched offset"
+# - eos cp fails with "No space left on device"
+# expect to see stat.active=online four times!
+while [ "$(eos fs ls -m | grep stat.active=online | wc -l)" -lt 4 ]; do
+  echo "waiting for fst to come online in 'eos fs ls' ..."
+  sleep 5
+  eos space set default on
+  sleep 5
+  eos fs ls
+done
 
 ## cern style eos docker root default namespace
 eos mkdir -p /eos/dockertest/reva/users


### PR DESCRIPTION
1. fixes #7 by enabling the trashbin
2. enable the space more reliably by waiting for it to be online and retrying 