### PR TITLE
Update EOS to 4.8.26

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -7,8 +7,8 @@ config = {
     'eos-mq',
     'eos-qdb',
   ],
-  'eos_version': '4.6.5',
-  'qdb_version': '0.4.0',
+  'eos_version': '4.8.26',
+  'qdb_version': '0.4.2',
 }
 
 def main(ctx):


### PR DESCRIPTION
# Updates

- EOS base image from `4.6.5` to `4.8.26`
- Quarkdb from `0.4.0` to `0.4.2`